### PR TITLE
Update to GenServer and correct deprecation warnings

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -25,7 +25,7 @@ defmodule JUnitFormatter do
   The report is written to a file in the _build directory.
   """
   require Record
-  use GenEvent
+  use GenServer
 
   # Needed to use :xmerl
   Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
@@ -57,10 +57,10 @@ defmodule JUnitFormatter do
   end
 
   ## Formatter callbacks: may use opts in the future to configure file name pattern
-    
+
   def init(_opts), do: {:ok, []}
 
-  def handle_event({:suite_finished, _run_us, _load_us}, config) do
+  def handle_cast({:suite_finished, _run_us, _load_us}, config) do
     # do the real magic
     suites = Enum.map config, &generate_testsuite_xml/1
     # wrap result in a root node (not adding any attribute to root)
@@ -77,47 +77,46 @@ defmodule JUnitFormatter do
       Logger.debug "Wrote JUnit report to: #{file_name}"
     end
 
-    # Release handler
-    :remove_handler
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{state: nil} = test}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{state: nil} = test}, config) do
 
     stats = adjust_case_stats(test, config)
     config = Keyword.put config, test.case, stats
 
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
 
     stats = adjust_case_stats(test, config)
     stats = %{stats | skipped: stats.skipped + 1}
     config = Keyword.put config, test.case, stats
 
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{state: {:failed, _failed}} = test}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:failed, _failed}} = test}, config) do
 
     stats = adjust_case_stats(test, config)
     stats = %{stats | failures: stats.failures + 1}
     config = Keyword.put config, test.case, stats
 
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{state: {:invalid, _module}} = test}, config) do
+  def handle_cast({:test_finished, %ExUnit.Test{state: {:invalid, _module}} = test}, config) do
 
     stats = adjust_case_stats(test, config)
     stats = %{stats | errors: stats.errors + 1}
     config = Keyword.put config, test.case, stats
 
-    {:ok, config}
+    {:noreply, config}
   end
 
-  def handle_event(_event, config) do
-    {:ok, config}
+  def handle_cast(_event, config) do
+    {:noreply, config}
   end
 
   @doc "Formats time from nanos to seconds"
@@ -183,8 +182,8 @@ defmodule JUnitFormatter do
   end
 
   defp generate_testcases(test) do
-    {:testcase, [classname: Atom.to_char_list(test.case),
-                 name: Atom.to_char_list(test.name),
+    {:testcase, [classname: Atom.to_charlist(test.case),
+                 name: Atom.to_charlist(test.name),
                  time: test.time |> us_to_ms |> format_ms],
      generate_test_body(test)
     }
@@ -205,7 +204,7 @@ defmodule JUnitFormatter do
         %{message: message} -> message
         other -> inspect(other)
       end
-    [{:failure, [message: Atom.to_string(kind) <> ": " <> message], [String.to_char_list(formatted_stack)]}]
+    [{:failure, [message: Atom.to_string(kind) <> ": " <> message], [String.to_charlist(formatted_stack)]}]
   end
   defp generate_test_body(%ExUnit.Test{state: {:invalid, module}}) do
     [{:error, [message: "Invalid module #{inspect module}"], []}]


### PR DESCRIPTION
## Why?

Elixir 1.5 deprecation warnings:
```sh
warning: passing GenEvent handlers (JUnitFormatter in this case) in the :formatters option of ExUnit is deprecated, please pass a GenServer instead. Check the documentation for the ExUnit.Formatter module for more information
  (ex_unit) lib/ex_unit/event_manager.ex:34: ExUnit.EventManager.add_handler/3
  (elixir) lib/enum.ex:675: Enum."-each/2-lists^foreach/1-0-"/2
  (elixir) lib/enum.ex:675: Enum.each/2
  (ex_unit) lib/ex_unit/runner.ex:29: ExUnit.Runner.configure/1
  (ex_unit) lib/ex_unit/runner.ex:7: ExUnit.Runner.run/2
```

## Correction
* Update to use `GenServer` vs. `GenEvent` behaviour.
* Update to correct various function deprecation warnings.